### PR TITLE
Made EquivalentTo aware of absolute paths

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -478,9 +478,21 @@ func (p *Path) EqualsTo(other *Path) bool {
 }
 
 // EquivalentTo return true if both paths are equivalent (they points to the
-// same file even if they are lexicographically different)
+// same file even if they are lexicographically different) based on the current
+// working directory.
 func (p *Path) EquivalentTo(other *Path) bool {
-	return p.Clean().path == other.Clean().path
+	if p.Clean().path == other.Clean().path {
+		return true
+	}
+	absP, err := p.Abs()
+	if err != nil {
+		return false
+	}
+	absOther, err := other.Abs()
+	if err != nil {
+		return false
+	}
+	return absP.path == absOther.path
 }
 
 // Parents returns all the parents directories of the current path. If the path is absolute

--- a/paths_test.go
+++ b/paths_test.go
@@ -302,3 +302,12 @@ func TestFilterOutDirs(t *testing.T) {
 	require.Equal(t, "_testdata/anotherFile", list[0].String())
 	require.Equal(t, "_testdata/file", list[1].String())
 }
+
+func TestEquivalentPaths(t *testing.T) {
+	wd, err := Getwd()
+	require.NoError(t, err)
+	require.True(t, New("file1").EquivalentTo(New("file1", "somethingelse", "..")))
+	require.True(t, New("file1", "abc").EquivalentTo(New("file1", "abc", "def", "..")))
+	require.True(t, wd.Join("file1").EquivalentTo(New("file1")))
+	require.True(t, wd.Join("file1").EquivalentTo(New("file1", "abc", "..")))
+}


### PR DESCRIPTION
Previously:
`paths.New("/home/cmaglie/file").EquivalentTo(paths.New("file"))`
would return `false` even if the current working directory was `/home/cmaglie`.
This PR fix this problem.
