### PR TITLE
Added RelFrom and WriteToTempFile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/arduino/go-paths-helper
 
 go 1.12
 
-require github.com/stretchr/testify v1.3.0
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/paths.go
+++ b/paths.go
@@ -128,9 +128,25 @@ func (p *Path) HasSuffix(suffixies ...string) bool {
 }
 
 // RelTo returns a relative Path that is lexically equivalent to r when
-// joined to the current Path
+// joined to the current Path.
+//
+// For example paths.New("/my/path/ab/cd").RelTo(paths.New("/my/path"))
+// returns "../..".
 func (p *Path) RelTo(r *Path) (*Path, error) {
 	rel, err := filepath.Rel(p.path, r.path)
+	if err != nil {
+		return nil, err
+	}
+	return New(rel), nil
+}
+
+// RelFrom returns a relative Path that when joined with r is lexically
+// equivalent to the current path.
+//
+// For example paths.New("/my/path/ab/cd").RelFrom(paths.New("/my/path"))
+// returns "ab/cd".
+func (p *Path) RelFrom(r *Path) (*Path, error) {
+	rel, err := filepath.Rel(r.path, p.path)
 	if err != nil {
 		return nil, err
 	}

--- a/paths_test.go
+++ b/paths_test.go
@@ -311,3 +311,29 @@ func TestEquivalentPaths(t *testing.T) {
 	require.True(t, wd.Join("file1").EquivalentTo(New("file1")))
 	require.True(t, wd.Join("file1").EquivalentTo(New("file1", "abc", "..")))
 }
+
+func TestRelativeTo(t *testing.T) {
+	res, err := New("/my/abs/path/123/456").RelTo(New("/my/abs/path"))
+	require.NoError(t, err)
+	require.Equal(t, "../..", res.String())
+
+	res, err = New("/my/abs/path").RelTo(New("/my/abs/path/123/456"))
+	require.NoError(t, err)
+	require.Equal(t, "123/456", res.String())
+
+	res, err = New("my/path").RelTo(New("/other/path"))
+	require.Error(t, err)
+	require.Nil(t, res)
+
+	res, err = New("/my/abs/path/123/456").RelFrom(New("/my/abs/path"))
+	require.Equal(t, "123/456", res.String())
+	require.NoError(t, err)
+
+	res, err = New("/my/abs/path").RelFrom(New("/my/abs/path/123/456"))
+	require.NoError(t, err)
+	require.Equal(t, "../..", res.String())
+
+	res, err = New("my/path").RelFrom(New("/other/path"))
+	require.Error(t, err)
+	require.Nil(t, res)
+}

--- a/paths_test.go
+++ b/paths_test.go
@@ -31,6 +31,7 @@ package paths
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -336,4 +337,19 @@ func TestRelativeTo(t *testing.T) {
 	res, err = New("my/path").RelFrom(New("/other/path"))
 	require.Error(t, err)
 	require.Nil(t, res)
+}
+
+func TestWriteToTempFile(t *testing.T) {
+	tmpDir := New("_testdata", "tmp")
+	tmpData := []byte("test")
+	tmp, err := WriteToTempFile(tmpData, tmpDir, "prefix")
+	defer tmp.Remove()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(tmp.Base(), "prefix"))
+	inside, err := tmp.IsInsideDir(tmpDir)
+	require.NoError(t, err)
+	require.True(t, inside)
+	data, err := tmp.ReadFile()
+	require.NoError(t, err)
+	require.Equal(t, tmpData, data)
 }


### PR DESCRIPTION
`x.RelFrom(y)` does the same job of `x.RelTo(y)` (but with the arguments inverted).

`WriteToTempFile` writes a buffer into a temp file and returns a `*Path` to that file.

I often find myself requiring those two helpers, so I've implemented them here.