### PR TITLE
Removed windows-2016 runner from CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,6 @@ jobs:
             ubuntu-latest,
             ubuntu-18.04,
             windows-latest,
-            windows-2016,
             macos-latest,
           ]
 


### PR DESCRIPTION
It is no more available: https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022/