### PR TITLE
Removed ubuntu-18.04 runner from CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,6 @@ jobs:
         operating-system:
           [
             ubuntu-latest,
-            ubuntu-18.04,
             windows-latest,
             macos-latest,
           ]


### PR DESCRIPTION
Has been deprecated https://github.com/actions/runner-images/issues/6002