### PR TITLE
Fix `Pahts.IsInsideDir` method when paths belongs to different drives/filesystem

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -191,7 +191,10 @@ func (p *Path) Clean() *Path {
 func (p *Path) IsInsideDir(dir *Path) (bool, error) {
 	rel, err := filepath.Rel(dir.path, p.path)
 	if err != nil {
-		return false, err
+		// If the dir cannot be made relative to this path it means
+		// that it belong to a different filesystems, so it cannot be
+		// inside this path.
+		return false, nil
 	}
 	return !strings.Contains(rel, ".."+string(os.PathSeparator)) && rel != ".." && rel != ".", nil
 }

--- a/paths.go
+++ b/paths.go
@@ -188,15 +188,17 @@ func (p *Path) Clean() *Path {
 
 // IsInsideDir returns true if the current path is inside the provided
 // dir
-func (p *Path) IsInsideDir(dir *Path) (bool, error) {
+func (p *Path) IsInsideDir(dir *Path) bool {
 	rel, err := filepath.Rel(dir.path, p.path)
 	if err != nil {
 		// If the dir cannot be made relative to this path it means
 		// that it belong to a different filesystems, so it cannot be
 		// inside this path.
-		return false, nil
+		return false
 	}
-	return !strings.Contains(rel, ".."+string(os.PathSeparator)) && rel != ".." && rel != ".", nil
+	return !strings.Contains(rel, ".."+string(os.PathSeparator)) &&
+		rel != ".." &&
+		rel != "."
 }
 
 // Parent returns all but the last element of path, typically the path's

--- a/paths_test.go
+++ b/paths_test.go
@@ -155,15 +155,11 @@ func TestResetStatCacheWhenFollowingSymlink(t *testing.T) {
 
 func TestIsInsideDir(t *testing.T) {
 	notInside := func(a, b *Path) {
-		in, err := a.IsInsideDir(b)
-		require.NoError(t, err)
-		require.False(t, in, "%s is inside %s", a, b)
+		require.False(t, a.IsInsideDir(b), "%s is inside %s", a, b)
 	}
 
 	inside := func(a, b *Path) {
-		in, err := a.IsInsideDir(b)
-		require.NoError(t, err)
-		require.True(t, in, "%s is inside %s", a, b)
+		require.True(t, a.IsInsideDir(b), "%s is inside %s", a, b)
 		notInside(b, a)
 	}
 
@@ -381,9 +377,7 @@ func TestWriteToTempFile(t *testing.T) {
 	defer tmp.Remove()
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(tmp.Base(), "prefix"))
-	inside, err := tmp.IsInsideDir(tmpDir)
-	require.NoError(t, err)
-	require.True(t, inside)
+	require.True(t, tmp.IsInsideDir(tmpDir))
 	data, err := tmp.ReadFile()
 	require.NoError(t, err)
 	require.Equal(t, tmpData, data)

--- a/paths_test.go
+++ b/paths_test.go
@@ -154,16 +154,17 @@ func TestResetStatCacheWhenFollowingSymlink(t *testing.T) {
 }
 
 func TestIsInsideDir(t *testing.T) {
-	inside := func(a, b *Path) {
-		in, err := a.IsInsideDir(b)
-		require.NoError(t, err)
-		require.True(t, in, "%s is inside %s", a, b)
-	}
-
 	notInside := func(a, b *Path) {
 		in, err := a.IsInsideDir(b)
 		require.NoError(t, err)
 		require.False(t, in, "%s is inside %s", a, b)
+	}
+
+	inside := func(a, b *Path) {
+		in, err := a.IsInsideDir(b)
+		require.NoError(t, err)
+		require.True(t, in, "%s is inside %s", a, b)
+		notInside(b, a)
 	}
 
 	f1 := New("/a/b/c")
@@ -196,6 +197,14 @@ func TestIsInsideDir(t *testing.T) {
 	f5 := New("/home/megabug/a15/packages")
 	notInside(f5, f4)
 	notInside(f4, f5)
+
+	if runtime.GOOS == "windows" {
+		f6 := New("C:\\", "A")
+		f7 := New("C:\\", "A", "B", "C")
+		f8 := New("E:\\", "A", "B", "C")
+		inside(f7, f6)
+		notInside(f8, f6)
+	}
 }
 
 func TestReadFileAsLines(t *testing.T) {


### PR DESCRIPTION
When comparing two paths from different drives like:

```go
a := paths.New(`C:\AAA\BBB`)
b := paths.New(`D:\AAA\BBB\CCC`)
fmt.Println(b.IsInsideDir(a))
```

the function `IsInsideDir` returns an error instead of the correct result `false`.
See https://github.com/arduino/arduino-cli/issues/2156 for a real-world use case.
