### PR TITLE
Fix CopyTo same filepath truncate the file

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -317,6 +317,10 @@ func (p *Path) IsDirCheck() (bool, error) {
 // of the source file. The file mode will be copied from the source and
 // the copied data is synced/flushed to stable storage.
 func (p *Path) CopyTo(dst *Path) error {
+	if p.EqualsTo(dst) {
+		return fmt.Errorf("%s and %s are the same file", p.path, dst.path)
+	}
+
 	in, err := os.Open(p.path)
 	if err != nil {
 		return err

--- a/paths_test.go
+++ b/paths_test.go
@@ -388,3 +388,21 @@ func TestWriteToTempFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tmpData, data)
 }
+
+func TestCopyToSamePath(t *testing.T) {
+	tmpDir := New(t.TempDir())
+	srcFile := tmpDir.Join("test_file")
+	dstFile := srcFile
+
+	// create the source file in tmp dir
+	err := srcFile.WriteFile([]byte("hello"))
+	require.NoError(t, err)
+	content, err := srcFile.ReadFile()
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), content)
+
+	// cannot copy the same file
+	err = srcFile.CopyTo(dstFile)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "are the same file")
+}


### PR DESCRIPTION
## Issue
When trying to copy the same file from `src` to `dst` the `CopyTo` functions truncate
the dst file.

Example:
src=dst=/tmp/a

/tmp/a -> content: "hello"
src.CopyTo(dst)
/tmp/a -> content: ""


## New behaviour
Copying an existing file to the same directory throws an error.
