### PR TITLE
Improvements to Process.Kill() method.

### DIFF
--- a/process.go
+++ b/process.go
@@ -55,7 +55,8 @@ func NewProcess(extraEnv []string, args ...string) (*Process, error) {
 		cmd: exec.Command(args[0], args[1:]...),
 	}
 	p.cmd.Env = append(os.Environ(), extraEnv...)
-	p.TellCommandNotToSpawnShell()
+	tellCommandNotToSpawnShell(p.cmd)          // windows specific
+	tellCommandToStartOnNewProcessGroup(p.cmd) // linux specific
 
 	// This is required because some tools detects if the program is running
 	// from terminal by looking at the stdin/out bindings.
@@ -146,7 +147,7 @@ func (p *Process) Signal(sig os.Signal) error {
 // actually exited. This only kills the Process itself, not any other processes it may
 // have started.
 func (p *Process) Kill() error {
-	return p.cmd.Process.Kill()
+	return kill(p.cmd)
 }
 
 // SetDir sets the working directory of the command. If Dir is the empty string, Run

--- a/process_linux.go
+++ b/process_linux.go
@@ -27,6 +27,8 @@
 // the GNU General Public License.
 //
 
+//go:build !windows
+
 package paths
 
 import (
@@ -34,17 +36,29 @@ import (
 	"syscall"
 )
 
-func tellCommandNotToSpawnShell(oscmd *exec.Cmd) {
-	if oscmd.SysProcAttr == nil {
-		oscmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	oscmd.SysProcAttr.HideWindow = true
-}
-
-func tellCommandToStartOnNewProcessGroup(_ *exec.Cmd) {
+func tellCommandNotToSpawnShell(_ *exec.Cmd) {
 	// no op
 }
 
+func tellCommandToStartOnNewProcessGroup(oscmd *exec.Cmd) {
+	// https://groups.google.com/g/golang-nuts/c/XoQ3RhFBJl8
+
+	// Start the process in a new process group.
+	// This is needed to kill the process and its children
+	// if we need to kill the process.
+	if oscmd.SysProcAttr == nil {
+		oscmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	oscmd.SysProcAttr.Setpgid = true
+}
+
 func kill(oscmd *exec.Cmd) error {
-	return oscmd.Process.Kill()
+	// https://groups.google.com/g/golang-nuts/c/XoQ3RhFBJl8
+
+	// Kill the process group
+	pgid, err := syscall.Getpgid(oscmd.Process.Pid)
+	if err != nil {
+		return err
+	}
+	return syscall.Kill(-pgid, syscall.SIGKILL)
 }

--- a/process_others.go
+++ b/process_others.go
@@ -27,12 +27,22 @@
 // the GNU General Public License.
 //
 
-//go:build !windows
+//go:build !windows && !linux
 
 package paths
 
-import "os/exec"
+import (
+	"os/exec"
+)
 
 func tellCommandNotToSpawnShell(_ *exec.Cmd) {
 	// no op
+}
+
+func tellCommandToStartOnNewProcessGroup(_ *exec.Cmd) {
+	// no op
+}
+
+func kill(oscmd *exec.Cmd) error {
+	return oscmd.Process.Kill()
 }


### PR DESCRIPTION
When running processes with the capture of stdin/stdout, the `Kill` method will not work properly on Linux.
It seems that a child process is spawned, so it's needed to create a process group and kill the process group (that will also catch the children process).

https://groups.google.com/g/golang-nuts/c/XoQ3RhFBJl8
