### PR TITLE
`Kill` now kills all the childrens in the process-tree on MacOS and Windows.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,13 @@
 module github.com/arduino/go-paths-helper
 
-go 1.21
+go 1.23.0
 
-require github.com/stretchr/testify v1.8.4
+toolchain go1.23.2
+
+require (
+	github.com/stretchr/testify v1.8.4
+	golang.org/x/sys v0.32.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/process.go
+++ b/process.go
@@ -56,7 +56,7 @@ func NewProcess(extraEnv []string, args ...string) (*Process, error) {
 	}
 	p.cmd.Env = append(os.Environ(), extraEnv...)
 	tellCommandNotToSpawnShell(p.cmd)          // windows specific
-	tellCommandToStartOnNewProcessGroup(p.cmd) // linux specific
+	tellCommandToStartOnNewProcessGroup(p.cmd) // linux and macosx specific
 
 	// This is required because some tools detects if the program is running
 	// from terminal by looking at the stdin/out bindings.
@@ -67,6 +67,8 @@ func NewProcess(extraEnv []string, args ...string) (*Process, error) {
 
 // TellCommandNotToSpawnShell avoids that the specified Cmd display a small
 // command prompt while runnning on Windows. It has no effects on other OS.
+//
+// Deprecated: TellCommandNotToSpawnShell is now always applied by default, there is no need to call it anymore.
 func (p *Process) TellCommandNotToSpawnShell() {
 	tellCommandNotToSpawnShell(p.cmd)
 }

--- a/process_darwin.go
+++ b/process_darwin.go
@@ -27,22 +27,36 @@
 // the GNU General Public License.
 //
 
-//go:build !windows && !linux && !darwin
-
 package paths
 
 import (
 	"os/exec"
+	"syscall"
 )
 
 func tellCommandNotToSpawnShell(_ *exec.Cmd) {
 	// no op
 }
 
-func tellCommandToStartOnNewProcessGroup(_ *exec.Cmd) {
-	// no op
+func tellCommandToStartOnNewProcessGroup(oscmd *exec.Cmd) {
+	// https://groups.google.com/g/golang-nuts/c/XoQ3RhFBJl8
+
+	// Start the process in a new process group.
+	// This is needed to kill the process and its children
+	// if we need to kill the process.
+	if oscmd.SysProcAttr == nil {
+		oscmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	oscmd.SysProcAttr.Setpgid = true
 }
 
 func kill(oscmd *exec.Cmd) error {
-	return oscmd.Process.Kill()
+	// https://groups.google.com/g/golang-nuts/c/XoQ3RhFBJl8
+
+	// Kill the process group
+	pgid, err := syscall.Getpgid(oscmd.Process.Pid)
+	if err != nil {
+		return err
+	}
+	return syscall.Kill(-pgid, syscall.SIGKILL)
 }


### PR DESCRIPTION
The `Kill` method now kills the process group on MacOS (in a similar way we did for Linux) and Windows.

The Windows parts are a bit convoluted but seem to work nicely.